### PR TITLE
Update exporter apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 > -   **Fixed**: for any bug fixes.
 > -   **Security**: in case of vulnerabilities.
 
-## [[UNRELEASED](https://github.com/sysflow-telemetry/sf-exporter/compare/0.1-rc4...HEAD)]
+## [[UNRELEASED](https://github.com/sysflow-telemetry/sf-exporter/compare/0.1.0-rc4...HEAD)]
 
-## [[0.1-rc4](https://github.com/sysflow-telemetry/sf-exporter/compare/0.1-rc3...0.1-rc4)] - 2020-07-20
+## [[0.1.0-rc4](https://github.com/sysflow-telemetry/sf-exporter/compare/0.1-rc3...0.1.0-rc4)] - 2020-07-30
 
 ### Added
 
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Tracking latest Python APIs.
 - Improves rsyslog handling.
 - Increased `sf-exporter` version to the latest release candidate 0.1-rc4.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Added labels to exporter image.
-- Added licence to exporter image.
+- Added license to exporter image.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Supported tags and respective `Dockerfile` links
 
--	[`0.1-rc3`](https://github.com/sysflow-telemetry/sf-exporter/blob/0.1-rc3/Dockerfile), [`latest`](https://github.com/sysflow-telemetry/sf-exporter/blob/master/Dockerfile)
+-	[`0.1.0-rc4`](https://github.com/sysflow-telemetry/sf-exporter/blob/0.1.0-rc4/Dockerfile), [`latest`](https://github.com/sysflow-telemetry/sf-exporter/blob/master/Dockerfile)
 
 # Quick reference
 


### PR DESCRIPTION
### Added

- Added labels to exporter image.
- Added license to exporter image.

### Changed

- Tracking latest Python APIs.
- Improves rsyslog handling.
- Increased `sf-exporter` version to the latest release candidate 0.1-rc4.